### PR TITLE
Adds piece of state for canvas to exportProject route

### DIFF
--- a/src/routes/callback.js
+++ b/src/routes/callback.js
@@ -44,6 +44,8 @@ export async function get (request) {
   // get user info from Github
   const user = await getUser(token);
   request.locals.user = user.login;
+  // get canvas state from cookie
+  const state = request.locals.state;
   
   if (repoName) {
     await axios({
@@ -52,7 +54,8 @@ export async function get (request) {
       data: {
         token: token,
         user: user,
-        repoName 
+        repoName,
+        state 
       }
     });
   }

--- a/src/routes/exportProject.js
+++ b/src/routes/exportProject.js
@@ -15,6 +15,9 @@ export async function post({ request }) {
 
   // Store the repo name
   const repo = body.repoName.replace(/\s+/g,'-');
+
+  // Store the canvas state
+  const state = body.state;
   
     // Store a custom Octokit object with rest API plugin
     const CustomOctokit = Octokit.plugin(restEndpointMethods);
@@ -126,8 +129,8 @@ export async function post({ request }) {
     // Create new GitHub repo named the value of repo 
     await octokit.rest.repos.createForAuthenticatedUser({ name: repo, auto_init: true });
    
-    // Create component files from user prototype
-    const componentFiles = fileUtility.createFile();
+    // Create component files from user prototype, passing state from cookies
+    const componentFiles = fileUtility.createFile(state);
 
     // Get the static project files
     const projectFiles = await axios.get('https://app.svetch.io/api/projectFiles')
@@ -135,7 +138,7 @@ export async function post({ request }) {
       .then(({ files }) => files);
 
     // Get git blobs from the project and component files for the commit
-    const blobs = await getBlobs([ ...projectFiles, ... componentFiles ]);
+    const blobs = await getBlobs([ ...projectFiles, ...componentFiles ]);
 
     // Create the tree structure for the blobs
     const tree = await createTreeStructure(blobs);

--- a/src/utils/fileUtility.js
+++ b/src/utils/fileUtility.js
@@ -106,7 +106,10 @@ fileUtility.formatName = name => {
 		.join('');
 }
 
-fileUtility.createFile = () => {
+fileUtility.createFile = (canvasUpdate = null) => {
+	// If updates needed, update canvas store from argument
+	if (canvasUpdate) canvas.set(JSON.parse(canvasUpdate).canvas);
+	
 	// Get file template objects frome the parse method
 	const filesTemplates = fileUtility.parse('index', true);
 


### PR DESCRIPTION
BG: the webhook that injects stored canvas state from cookie storage into web app does not fire on the exportProject route because the exportProject route does not render any components. This PR uses the cookie storage to obtain the canvas state and pass it to the exportProject request. 